### PR TITLE
feat: ZustandストアとUIの統合 (#8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lucide-react": "^0.511.0",
     "motion": "^12.15.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      zustand:
+        specifier: ^5.0.5
+        version: 5.0.5(@types/react@19.1.6)(react@19.1.0)
     devDependencies:
       '@eslint/js':
         specifier: ^9.15.0
@@ -2210,6 +2213,24 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zustand@5.0.5:
+    resolution: {integrity: sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@adobe/css-tools@4.4.3': {}
@@ -4142,3 +4163,8 @@ snapshots:
   yaml@2.8.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.5(@types/react@19.1.6)(react@19.1.0):
+    optionalDependencies:
+      '@types/react': 19.1.6
+      react: 19.1.0

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,20 @@
 import { useEffect } from 'react'
 import './App.css'
-import { useAudioManager } from './hooks/useAudioManager'
+import { useAudioStore } from './stores/audioStore'
 import { SOUND_SOURCES } from './data/sounds'
 import { SoundCard } from './components/SoundCard'
 import { PlayingCounter } from './components/PlayingCounter'
 
 function App() {
   const {
-    playingSounds,
     play,
     stop,
     setVolume,
     isPlaying,
     getVolume,
     loadSound,
-  } = useAudioManager()
+    getPlayingCount,
+  } = useAudioStore()
 
   // 音源を事前に読み込む
   useEffect(() => {
@@ -39,7 +39,7 @@ function App() {
     <div className="min-h-screen bg-gray-900 text-white p-8">
       <h1 className="text-4xl font-bold mb-8 text-center">AmbientFlow</h1>
 
-      <PlayingCounter count={playingSounds.length} />
+      <PlayingCounter count={getPlayingCount()} />
 
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-w-6xl mx-auto">
         {SOUND_SOURCES.map((source) => (

--- a/src/types/sound.test.ts
+++ b/src/types/sound.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import type { SoundSource, SoundCategory, IconName } from './sound'
+import type { SoundSource, SoundCategory } from './sound'
 
 describe('sound types', () => {
   describe('SoundCategory', () => {
@@ -17,9 +17,9 @@ describe('sound types', () => {
     })
   })
 
-  describe('IconName', () => {
-    it('should accept valid icon names', () => {
-      const validIcons: IconName[] = [
+  describe('Icon names', () => {
+    it('should accept valid icon names as strings', () => {
+      const validIcons = [
         'CloudRain',
         'Waves',
         'Bird',


### PR DESCRIPTION
## Summary
- App.tsxでZustandストアを使用するように変更
- zustand依存関係をpackage.jsonに追加  
- 型定義の簡略化（IconName型の削除）

## Changes
- `useAudioManager`から`useAudioStore`への移行
- `playingSounds`配列の代わりに`getPlayingCount()`セレクターを使用
- テストファイルの型定義を更新

## Test plan
[x] ESLint/Prettierのチェックが通ることを確認
[x] pre-commitフックが正常に動作することを確認
[ ] pnpm installでzustandがインストールされることを確認
[ ] アプリケーションの動作確認（次フェーズ）

## Related
- #8 Feature: Zustand状態管理の実装

🤖 Generated with [Claude Code](https://claude.ai/code)